### PR TITLE
Fix minor typos in currently published part of the script

### DIFF
--- a/script/source/index.rst
+++ b/script/source/index.rst
@@ -11,7 +11,7 @@ Some links to motivational Haskell source files:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Capters:
+   :caption: Chapters:
    :numbered:
 
    tools

--- a/script/source/syntax.rst
+++ b/script/source/syntax.rst
@@ -4,12 +4,12 @@
 Fundamentals of the Haskell syntax
 ==================================
 
-This lesson contains gets us started with the basics of Haskell syntax.
-Haskell is an old language (older than Java) and also one with which people like to experiment.
+This lesson gets us started with the basics of Haskell syntax.
+Haskell is an old language (older than Java) and also one people like to experiment with.
 As a result a lot of extra syntax has accumulated in over the years.
 Some of it in regular use, some of it more obscure and not well known.
 Most of this extra syntax is hidden behind language extensions.
-We mway come to learn some of it in future lessons, however for now we will simply start with the ML style core of the Haskell syntax.
+We may come to learn some of it in future lessons, however for now we will simply start with the ML style core of the Haskell syntax.
 
 
 .. _comments:
@@ -47,11 +47,11 @@ Examples from Haskell's base library are:
 ``Bool``
     A boolean.
 
-After that the allowed characters are word character, digits, the underscore ``_`` and the apostrope ``'`` (often called *"prime"*).[#type-operators]
+After that the allowed characters are word characters, digits, the underscore ``_`` and the apostrophe ``'`` (often called *"prime"*).[#type-operators]
 Therefore a name such as ``Isn't_4_bool`` is a valid type name.
 
 In general Haskell is a type inferred language, meaning you rarley have to specify the type of a value or expression (although it is common practice to annotate top level types and values with type signatures).
-You can hovever annotate any value and expression you want with a type signature.
+You can however annotate any value and expression you want with a type signature.
 The special operator ``::`` can be used to achieve this (see also next section for examples).
 This is particularly useful when chasing down the source of type errors as you can fix expressions to a certain type you expect them to be.
 
@@ -66,7 +66,7 @@ Numbers
     If you wish to specify the type you can annotate the literal like so ``(3 :: Int)``, ``(3 :: Integer)`` or ``(3.5 :: Float)``, ``(3.5 :: Double)``.
 
 Characters
-    Character literals are constructed by surrounding a character or excape sequence with single quotes.
+    Character literals are constructed by surrounding a character or escape sequence with single quotes.
 
     ``'a'``, ``'H'``, ``'5'``, ``'.'``.
 
@@ -79,7 +79,7 @@ Strings
 
     ``"Hello World"``, ``"Foo\nBar"``
 
-    The same escape sequences as for characters apply with addition of the excaped double quotes ``\"``.
+    The same escape sequences as for characters apply with addition of the escaped double quotes ``\"``.
     [#overloaded-strings]_
 
 Lists
@@ -115,7 +115,7 @@ Since these ergo they are **not** "variable" (they cannot vary).
 This is why I prefer the name "binding" as it **binds** a value to an identifier, not a variable, as it cannot "vary".
 
 Bindings must always start with a lowercase letter.
-Then, like the types, it may contain word characters, digits, the underscore and the apostrope. [#naming-convention]_
+Then, like the types, it may contain word characters, digits, the underscore and the apostrophe. [#naming-convention]_
 
 There are several ways to bind a value.
 The first one we will learn (because it is the way to bind values in GHCi) is called ``let`` with the concrete syntax ``let name = value``.

--- a/script/source/tools.rst
+++ b/script/source/tools.rst
@@ -1,7 +1,7 @@
 The tools we will need
 ======================
 
-This fist lesson is all about the various tools we will use to develop Haskell code.
+This first lesson is all about the various tools we will use to develop Haskell code.
 
 .. _GHC:
 
@@ -93,7 +93,7 @@ Whereas on hackage you may only search the database by package name on hoogle yo
 Stackage
 ^^^^^^^^
 
-The `stackage`_ site, which host resources to be used with the tool ``stack`` functions similarly to a combination of Hackage and Hoogle.
+The `stackage`_ site, which hosts resources to be used with the tool ``stack`` functions similarly to a combination of Hackage and Hoogle.
 It hosts the documentation, including a Hoogle search, for each package snapshot.
 I therefore recommend to use stackage to browse haskell packages and documentation, unless the package you want information on is not on Stackage.
 
@@ -118,7 +118,7 @@ Also a special mention is to be given to `Haskell for Mac`_ a particularly beaut
 .. _atom-haskell: https://atom-haskell.github.io/
 
 And lastly I want to mention `ghcid <https://www.stackage.org/lts-8.9/package/ghcid>`__. 
-Its a very simple, command line based program which simply attempts to load your code into the interpreter an shows you the errors it encouters.
+Its a very simple, command line based program which simply attempts to load your code into the interpreter and shows you the errors it encouters.
 It automatically refreshes whenever you save a source file.
 This gives you some very bare bones ide features.
 The big advantage is that, unlike the other ide programs, ``ghcid`` is incredibly reliable.


### PR DESCRIPTION
I just read the currently available part of the script and found some minor typos I fixed.

There is also something wrong with line 50 in `syntax.rst`.
It's missing the footnote for `[#type-operators]`.

Good read so far! Keep it up 🙂 